### PR TITLE
mate-build-updates.sh: Added to detect and build updates.

### DIFF
--- a/mate-build-updates.sh
+++ b/mate-build-updates.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+
+# Copyright 2012  Patrick J. Volkerding, Sebeka, Minnesota, USA
+# All rights reserved.
+#
+# Copyright 2013 Chess Griffin <chess.griffin@gmail.com> Raleigh, NC
+# Copyright 2013 Willy Sudiarto Raharjo <willysr@slackware-id.org>
+# Copyright 2015 Antonio Hernández Blas <hba.nihilismus@gmail.com>
+# All rights reserved.
+#
+# Based on the xfce-build-all.sh script by Patrick J. Volkerding
+#
+# Redistribution and use of this script, with or without modification, is
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of this script must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+#  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+#  EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+#  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+#  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Set to 1 if you'd like to install/upgrade package as they are built.
+# This is recommended.
+INST=1
+
+# This is where all the compilation and final results will be placed
+TMP=${TMP:-/tmp}
+
+# This is the original directory where you started this script
+MSBROOT=$(pwd)
+
+# Loop for all base packages
+for dir in \
+  $(find deps/ base/ extra/ -type d -maxdepth 1 -mindepth 1) \
+  ; do
+  # Get the package name
+  package=$(echo $dir | cut -f2- -d /)
+
+  # Change to package directory
+  cd $MSBROOT/$dir || exit 1
+
+  # Get the version
+  version=$(cat ${package}.SlackBuild | grep "VERSION:" | head -n1 | cut -d "-" -f2 | rev | cut -c 2- | rev)
+
+  # Get the build
+  build=$(cat ${package}.SlackBuild | grep "BUILD:" | cut -d "-" -f2 | rev | cut -c 2- | rev)
+
+  # Detect updates based on installed packages
+  installed=$(ls /var/log/packages/${package}-*-*-?_* 2>/dev/null)
+  if [ -z "${installed}" ]; then
+    if [ "${1}" = "-ls" ]; then
+      echo
+      echo "New or No-Installed: ${dir}"
+      echo "                     Version: $version"
+      echo "                     Build: $build"
+      echo
+    fi
+    # Package is not installed, so there is not an update.
+    continue
+  fi
+  if echo ${installed} | grep "\-${version}-" 1>/dev/null; then
+    if echo ${installed} | grep "\-${build}_" 1>/dev/null; then
+      # Installed package does have same version and build, so
+      # there is not an update.
+      continue
+    fi
+  fi
+  if [ "${1}" = "-ls" ]; then
+    echo
+    echo "Update: ${dir}"
+    echo "        Version: $version"
+    echo "        Build: $build"
+    echo "        Installed: $(basename $installed)"
+    echo
+    continue
+  fi
+
+  # Check for duplicate sources
+  sourcefile="$(ls -l $MSBROOT/$dir/${package}-*.tar.?z* | wc -l)"
+  if [ $sourcefile -gt 1 ]; then
+    echo "You have following duplicate sources:"
+    ls $MSBROOT/$dir/${package}-*.tar.?z* | cut -d " " -f1
+    echo "Please delete sources other than ${package}-$version to avoid problems"
+    exit 1
+  fi
+
+  # The real build starts here
+  sh ${package}.SlackBuild || exit 1
+  if [ "$INST" = "1" ]; then
+    PACKAGE=`ls $TMP/${package}-${version}-*-${build}*.txz`
+    if [ -f "$PACKAGE" ]; then
+      upgradepkg --install-new --reinstall "$PACKAGE"
+    else
+      echo "Error:  package to upgrade "$PACKAGE" not found in $TMP"
+      exit 1
+    fi
+  fi
+
+  # back to original directory
+  cd $MSBROOT
+done


### PR DESCRIPTION
Based on updated SlackBuilds in the repository and installed
packages, build the packages for these updated SlackBuilds.

The option '-ls' print "New or No-Installed" and "Update"
packages without doing their build.

"New or No-Installed" SlackBuilds are never builded.