### PR TITLE
libmatekbd: Fix conflict with newer glib

### DIFF
--- a/base/libmatekbd/libmatekbd.SlackBuild
+++ b/base/libmatekbd/libmatekbd.SlackBuild
@@ -75,6 +75,9 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# Fix conflict with newer glib
+sed -i 's/g_strv_equal/matekbd_strv_equal/g' libmatekbd/matekbd-keyboard-config.c
+ 
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
 ./configure \


### PR DESCRIPTION
I don't know if you plan to upgrade to 1.22 anytime soon, (I'm having issues building mate-settings-daemon-1.22.0?) but this fix fixes a conflict with the newer glib in current, until you do upgrade.