### PR TITLE
brisk-menu: Updated for version 0.6.2

### DIFF
--- a/testing/brisk-menu/brisk-menu.SlackBuild
+++ b/testing/brisk-menu/brisk-menu.SlackBuild
@@ -23,7 +23,7 @@
 #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 PRGNAM=brisk-menu
-VERSION=${VERSION:-0.5.0}
+VERSION=${VERSION:-0.6.2}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_msb}
 
@@ -35,7 +35,7 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-wget -c https://github.com/solus-project/${PRGNAM}/archive/v${VERSION}/${PRGNAM}-${VERSION}.tar.gz
+wget -c https://github.com/getsolus/${PRGNAM}/releases/download/v${VERSION}/${PRGNAM}-v${VERSION}.tar.gz
 
 CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
@@ -68,7 +68,7 @@ rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
 rm -rf $PRGNAM-$VERSION
-tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
+tar xvf $CWD/$PRGNAM-v$VERSION.tar.xz
 cd $PRGNAM-$VERSION
 chown -R root:root .
 find -L . \
@@ -83,7 +83,7 @@ meson --prefix=/usr \
       --buildtype=release \
       --localstatedir=/var \
       --libdir=lib${LIBDIRSUFFIX} \
-      --libexecdir=/usr/lib${LIBDIRSUFFIX}/colord \
+      --libexecdir=/usr/lib${LIBDIRSUFFIX}/$PRGNAM \
       --mandir=/usr/man \
       ../
 ninja

--- a/testing/brisk-menu/brisk-menu.SlackBuild
+++ b/testing/brisk-menu/brisk-menu.SlackBuild
@@ -35,7 +35,7 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-wget -c https://github.com/getsolus/${PRGNAM}/releases/download/v${VERSION}/${PRGNAM}-v${VERSION}.tar.gz
+wget -c https://github.com/getsolus/${PRGNAM}/releases/download/v${VERSION}/${PRGNAM}-v${VERSION}.tar.xz
 
 CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}

--- a/testing/brisk-menu/brisk-menu.SlackBuild
+++ b/testing/brisk-menu/brisk-menu.SlackBuild
@@ -22,10 +22,13 @@
 #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+cd $(dirname $0) ; CWD=$(pwd)
+
 PRGNAM=brisk-menu
 VERSION=${VERSION:-0.6.2}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_msb}
+PKGTYPE=${PKGTYPE:-txz}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
@@ -35,9 +38,13 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
+if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
+  echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
+  exit 0
+fi
+
 wget -c https://github.com/getsolus/${PRGNAM}/releases/download/v${VERSION}/${PRGNAM}-v${VERSION}.tar.xz
 
-CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
@@ -77,18 +84,23 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-mkdir -p build
+mkdir build
 cd build
-meson --prefix=/usr \
-      --buildtype=release \
-      --localstatedir=/var \
-      --libdir=lib${LIBDIRSUFFIX} \
-      --libexecdir=/usr/lib${LIBDIRSUFFIX}/$PRGNAM \
-      --mandir=/usr/man \
-      ../
-ninja
-DESTDIR=$PKG ninja install
-cd -
+  CFLAGS="$SLKCFLAGS" \
+  CXXFLAGS="$SLKCFLAGS" \
+  meson .. \
+    --buildtype=plain \
+    --infodir=/usr/info \
+    --libdir=/usr/lib${LIBDIRSUFFIX} \
+    --libexecdir=/usr/libexec/$PRGNAM \
+    --localstatedir=/var \
+    --mandir=/usr/man \
+    --prefix=/usr \
+    --sysconfdir=/etc \
+    -Dstrip=true
+  "${NINJA:=ninja}"
+  DESTDIR=$PKG ninja install
+cd ..
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
@@ -102,4 +114,4 @@ cat $CWD/slack-desc > $PKG/install/slack-desc
 cat $CWD/doinst.sh > $PKG/install/doinst.sh
 
 cd $PKG
-/sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.${PKGTYPE:-txz}
+/sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE


### PR DESCRIPTION
This menu works pretty well. I also made a patch to remove the compile schemas and update icon cache, but I didn't include it here.