### PR TITLE
mate-menus: Add patch "don't strip safety checks".

### DIFF
--- a/base/mate-menus/donot-strip-safety-checks.patch
+++ b/base/mate-menus/donot-strip-safety-checks.patch
@@ -1,0 +1,61 @@
+From abb1f769cb74772bce95681cb24202c390ae8755 Mon Sep 17 00:00:00 2001
+From: Victor Kareh <vkareh@redhat.com>
+Date: Fri, 3 Jul 2026 11:58:18 -0400
+Subject: [PATCH] build: don't strip safety checks
+
+Both meson and autotools were stripping g_return_if_fail calls in the
+preprocessor. This meant that when mozo hit a NULL tree root during menu
+reload, the guard in matemenu_tree_item_ref did nothing and it crashed
+instead of returning gracefully.
+
+We change the guards to direct NULL checks and enable debug mode as the
+default to fix this.
+
+Fixes mate-desktop/mozo#90
+---
+ changes to `meson.build' removed as it is not available in downloaded
+ release tarball.
+ configure.ac            | 2 +-
+ libmenu/matemenu-tree.c | 9 +++++++--
+ 2 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 4261842..d8335ee 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -10,7 +10,7 @@ AC_CONFIG_HEADERS(config.h)
+ 
+ AM_MAINTAINER_MODE
+ MATE_MAINTAINER_MODE_DEFINES
+-MATE_DEBUG_CHECK([no])
++MATE_DEBUG_CHECK
+ MATE_COMPILE_WARNINGS
+ 
+ # Before making a release, the LT_VERSION string should be modified.
+diff --git a/libmenu/matemenu-tree.c b/libmenu/matemenu-tree.c
+index f1ffa9d..293018b 100644
+--- a/libmenu/matemenu-tree.c
++++ b/libmenu/matemenu-tree.c
+@@ -1807,7 +1807,10 @@ gpointer
+ matemenu_tree_item_ref (gpointer itemp)
+ {
+   MateMenuTreeItem* item = (MateMenuTreeItem*) itemp;
+-  g_return_val_if_fail(item != NULL, NULL);
++
++  if (item == NULL)
++    return NULL;
++
+   g_return_val_if_fail(item->refcount > 0, NULL);
+ 
+   g_atomic_int_inc (&item->refcount);
+@@ -1822,7 +1825,9 @@ matemenu_tree_item_unref (gpointer itemp)
+ 
+   item = (MateMenuTreeItem *) itemp;
+ 
+-  g_return_if_fail (item != NULL);
++  if (item == NULL)
++    return;
++
+   g_return_if_fail (item->refcount > 0);
+ 
+   if (g_atomic_int_dec_and_test (&(item->refcount)))

--- a/base/mate-menus/mate-menus.SlackBuild
+++ b/base/mate-menus/mate-menus.SlackBuild
@@ -25,7 +25,7 @@
 
 PRGNAM=mate-menus
 VERSION=${VERSION:-1.28.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_msb}
 
 if [ -z "$ARCH" ]; then
@@ -77,6 +77,7 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+patch -p1 < $CWD/donot-strip-safety-checks.patch
 
 autoreconf -vif
 CFLAGS="$SLKCFLAGS" \


### PR DESCRIPTION
Refer to upstream issue [#90](https://github.com/mate-desktop/mozo/issues/90). `mate-menus` causes menu-editor `mozo` to segfault if we try to edit e.g., select/deselect items, click on properties and close that pop-up window, click on 'Preferences' or 'System' on left pane etc. 

This issue is fixed by upstream [commit abb1f76](https://github.com/mate-desktop/mate-menus/commit/abb1f769cb74772bce95681cb24202c390ae8755). The current PR adds this patch to `mate-menus` slackbuild sans the 'meson.build' part, as that file is not available in the release tarballs.

EDIT: Package locally built and tested for nearly 30m. No crashes observed.